### PR TITLE
go run *.go doesnt work due to changes to the .List and .Watch functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ An example of a custom Kubernetes controller that's only purpose is to watch for
 ```
 $ git clone https://github.com/trstringer/k8s-controller-core-resource
 $ cd k8s-controller-core-resource
+$ go get github.com/Sirupsen/logrus k8s.io/api/core/v1 k8s.io/apimachinery/pkg/apis/meta/v1 k8s.io/apimachinery/pkg/runtime k8s.io/apimachinery/pkg/util/runtime k8s.io/apimachinery/pkg/util/wait k8s.io/apimachinery/pkg/watch k8s.io/client-go/kubernetes k8s.io/client-go/tools/cache k8s.io/client-go/tools/clientcmd k8s.io/client-go/util/workqueue
 $ go run *.go
 ```
 

--- a/main.go
+++ b/main.go
@@ -51,11 +51,11 @@ func main() {
 		&cache.ListWatch{
 			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
 				// list all of the pods (core resource) in the deafult namespace
-				return client.CoreV1().Pods(meta_v1.NamespaceDefault).List(options)
+				return client.CoreV1().Pods(meta_v1.NamespaceDefault).List(context.TODO(), options)
 			},
 			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
 				// watch all of the pods (core resource) in the default namespace
-				return client.CoreV1().Pods(meta_v1.NamespaceDefault).Watch(options)
+				return client.CoreV1().Pods(meta_v1.NamespaceDefault).Watch(context.TODO(), options)
 			},
 		},
 		&api_v1.Pod{}, // the target type (Pod)


### PR DESCRIPTION
Unless I'm mistaken, the .List and .Watch functions now require a context argument, which I've added.  